### PR TITLE
Add dry run option

### DIFF
--- a/exe/tractive
+++ b/exe/tractive
@@ -7,6 +7,7 @@ class TractiveCommand < Thor
   class_option 'config', type: :string, default: 'trac-hub.config.yaml', banner: '<PATH>', aliases: '-c', desc: 'Set the configuration file'
   class_option 'start', type: :numeric, aliases: ['-s', '--start-at'], banner: '<ID>', desc: 'Start migration from ticket with number <ID>'
   class_option 'info', type: :boolean, aliases: ['-i', '--info'], desc: 'Reports existing labels and users in the database'
+  class_option 'dryrun', type: :boolean, aliases: ['-d', '--dry-run'], desc: 'Write data to a file instead of pushing it to github'
   class_option 'revmapfile', type: :string, aliases: ['-r', '--rev-map-file'], banner: '<PATH>', desc: 'Allows to specify a commit revision mapping FILE'
   class_option 'attachurl', type: :string, aliases: ['-a', '--attachment-url'], banner: '<URL>', desc: 'If attachment files are reachable via a URL we reference this here'
   class_option 'singlepost', type: :boolean, aliases: ['-S', '--single-post'], desc: 'Put all issue comments in the first message.'

--- a/lib/tractive/graceful_quit.rb
+++ b/lib/tractive/graceful_quit.rb
@@ -20,7 +20,7 @@ module Tractive
     def self.check(message = "Quitting")
       if self.instance.breaker
         yield if block_given?
-        $log.info message
+        $logger.info message
         exit
       end
     end

--- a/lib/tractive/migrator.rb
+++ b/lib/tractive/migrator.rb
@@ -194,7 +194,7 @@ module Tractive
 
         next if filterout_closed and ticket[:status] == "closed"
         GracefulQuit.check("quitting after processing ticket ##{@last_created_issue}") do
-          file.puts "]"
+          @output_file.puts "]"
         end
 
         if @safetychecks;


### PR DESCRIPTION
- Added an option `-d` or `--dry-run` for outputting trac data in a file without pushing to github.

Resolves #5 