### PR TITLE
Move db exporter scripts to tractive command

### DIFF
--- a/exe/tractive
+++ b/exe/tractive
@@ -4,18 +4,20 @@ require_relative '../lib/tractive'
 
 class TractiveCommand < Thor
   default_command :default
-  class_option 'config', type: :string, default: 'trac-hub.config.yaml', banner: '<PATH>', aliases: '-c', desc: 'Set the configuration file'
-  class_option 'start', type: :numeric, aliases: ['-s', '--start-at'], banner: '<ID>', desc: 'Start migration from ticket with number <ID>'
-  class_option 'info', type: :boolean, aliases: ['-i', '--info'], desc: 'Reports existing labels and users in the database'
-  class_option 'dryrun', type: :boolean, aliases: ['-d', '--dry-run'], desc: 'Write data to a file instead of pushing it to github'
-  class_option 'revmapfile', type: :string, aliases: ['-r', '--rev-map-file'], banner: '<PATH>', desc: 'Allows to specify a commit revision mapping FILE'
-  class_option 'attachurl', type: :string, aliases: ['-a', '--attachment-url'], banner: '<URL>', desc: 'If attachment files are reachable via a URL we reference this here'
-  class_option 'singlepost', type: :boolean, aliases: ['-S', '--single-post'], desc: 'Put all issue comments in the first message.'
-  class_option 'fast', type: :boolean, aliases: ['-F', '--fast-import'], desc: 'Import without safety-checking issue numbers.'
-  class_option 'mockdeleted', type: :boolean, aliases: ['-M', '--mockup'], desc: 'Import from 0 and mocking tickets deleted on trac'
   class_option 'attachmentexporter', type: :string, aliases: ['-A', '--attachment-exporter'], desc: 'Generate an attachment exporter script according to config.yaml'
+  class_option 'attachurl', type: :string, aliases: ['-a', '--attachment-url'], banner: '<URL>', desc: 'If attachment files are reachable via a URL we reference this here'
+  class_option 'config', type: :string, default: 'trac-hub.config.yaml', banner: '<PATH>', aliases: '-c', desc: 'Set the configuration file'
+  class_option 'dryrun', type: :boolean, aliases: ['-d', '--dry-run'], desc: 'Write data to a file instead of pushing it to github'
+  class_option 'exportattachments', type: :string, aliases: ['-e', '--export-attachments'], desc: 'Export attachments from the databse according to config.yaml'
+  class_option 'fast', type: :boolean, aliases: ['-F', '--fast-import'], desc: 'Import without safety-checking issue numbers.'
+  class_option 'info', type: :boolean, aliases: ['-i', '--info'], desc: 'Reports existing labels and users in the database'
+  class_option 'mockdeleted', type: :boolean, aliases: ['-M', '--mockup'], desc: 'Import from 0 and mocking tickets deleted on trac'
   class_option 'openedonly', type: :boolean, aliases: ['-o', '--opened-only'], desc: 'Skips the import of closed tickets'
+  class_option 'revmapfile', type: :string, aliases: ['-r', '--rev-map-file'], banner: '<PATH>', desc: 'Allows to specify a commit revision mapping FILE'
+  class_option 'singlepost', type: :boolean, aliases: ['-S', '--single-post'], desc: 'Put all issue comments in the first message.'
+  class_option 'start', type: :numeric, aliases: ['-s', '--start-at'], banner: '<ID>', desc: 'Start migration from ticket with number <ID>'
   class_option 'verbose', type: :boolean, aliases: ['-v', '--verbose'], desc: 'Verbose mode'
+
 
   def self.exit_on_failure?
     true

--- a/lib/tractive/attachment_exporter.rb
+++ b/lib/tractive/attachment_exporter.rb
@@ -1,3 +1,6 @@
+require 'fileutils'
+require 'open-uri'
+
 module Tractive
   class AttachmentExporter
     def initialize(cfg, db)
@@ -7,14 +10,14 @@ module Tractive
 
     # produce an shell script to be invoked
     # within the tracd container to export the attachmets
-    def generate
+    def generate_script
       outfile   = @cfg.dig("attachments", "export_script")
       outfolder = @cfg.dig("attachments", "export_folder")
 
       raise("mising attachements/export_script entry in configuration") unless outfile
       raise("mising attachements/export_folder entry in configuration") unless outfolder
 
-      attachments   = @db[:attachment].select(:id, :filename).where(type: 'ticket')
+      attachments   = Attachment.tickets_attachments.select(:id, :filename)
       exportcommads = attachments.map do |attachment|
         %Q{mkdir -p #{outfolder}/#{attachment[:id]}
         trac-admin /trac attachment export ticket:#{attachment[:id]} '#{attachment[:filename]}' > '#{outfolder}/#{attachment[:id]}/#{attachment[:filename]}'}
@@ -29,6 +32,29 @@ module Tractive
     rescue StandardError => e
       $logger.error(e.message)
       exit(1)
+    end
+
+    # export the images from the database into a folder
+    def export
+      output_dir = @cfg.dig('attachments', 'export_folder') || "#{Dir.pwd}/tmp/trac"
+      trac_url = @cfg.dig('attachments', 'url')
+
+      raise("attachments url is required in config.yaml to export attachments.") unless trac_url
+
+      FileUtils.mkdir_p output_dir
+      attachments = Attachment.tickets_attachments.select(:id, :filename)
+
+      # using URI::Parser.new because URI.encode raise warning: URI.escape is obsolete
+      uri_parser = URI::Parser.new
+
+      attachments.each do |attachment|
+        $logger.info "Saving attachments of ticket #{attachment.id}... "
+        FileUtils.mkdir_p "#{output_dir}/#{attachment.id}"
+
+        File.open("#{output_dir}/#{attachment.id}/#{attachment.filename}", "wb") do |file|
+          file.write URI.open(uri_parser.escape("#{trac_url}/#{attachment.id}/#{attachment.filename}")).read
+        end
+      end
     end
   end
 end

--- a/lib/tractive/main.rb
+++ b/lib/tractive/main.rb
@@ -16,6 +16,8 @@ module Tractive
       if @opts[:info]
         info
       elsif @opts[:attachmentexporter]
+        create_attachment_exporter_script
+      elsif @opts[:exportattachments]
         export_attachments
       else
         migrate
@@ -31,7 +33,11 @@ module Tractive
     end
 
     def export_attachments
-      Tractive::AttachmentExporter.new(@cfg, @db).generate
+      Tractive::AttachmentExporter.new(@cfg, @db).export
+    end
+
+    def create_attachment_exporter_script
+      Tractive::AttachmentExporter.new(@cfg, @db).generate_script
     end
   end
 end

--- a/lib/tractive/migrator.rb
+++ b/lib/tractive/migrator.rb
@@ -54,7 +54,7 @@ module Tractive
 
       @dry_run          = args[:opts][:dryrun]
       @output_file      = file = File.new(dry_run_output_file, 'w+')
-      @delimiter        = ''
+      @delimiter        = '['
       @revmap           = load_revmap_file(args[:opts][:revmapfile] || args[:cfg]['revmapfile'])
       @attachurl        = attachurl
       @singlepost       = singlepost
@@ -215,10 +215,9 @@ module Tractive
           request  = compose_issue(ticket)
 
           if @dry_run
-            @output_file.puts '[' if @delimiter == ''
             @output_file.puts @delimiter
             @output_file.puts request.to_json
-            @delimiter = ',' if @delimiter == ''
+            @delimiter = ',' if @delimiter == '['
             response = { 'status' => 'added to file', 'issue_url' => "/#{ticket[:id]}" }
           else
             response = JSON.parse(

--- a/lib/tractive/model/attachment.rb
+++ b/lib/tractive/model/attachment.rb
@@ -1,6 +1,9 @@
 module Tractive
-  module Model
-    class Attachment < Sequel::Model(:attachment)
+  class Attachment < Sequel::Model(:attachment)
+    dataset_module do
+      def tickets_attachments
+        filter(type: 'ticket')
+      end
     end
   end
 end

--- a/lib/tractive/model/change.rb
+++ b/lib/tractive/model/change.rb
@@ -1,6 +1,4 @@
 module Tractive
-  module Model
-    class Change < Sequel::Model(:ticket_change)
-    end
+  class Change < Sequel::Model(:ticket_change)
   end
 end

--- a/lib/tractive/model/session.rb
+++ b/lib/tractive/model/session.rb
@@ -1,6 +1,4 @@
 module Tractive
-  module Model
-    class Session < Sequel::Model(:session_attribute)
-    end
+  class Session < Sequel::Model(:session_attribute)
   end
 end

--- a/lib/tractive/model/subticket.rb
+++ b/lib/tractive/model/subticket.rb
@@ -1,6 +1,4 @@
 module Tractive
-  module Model
-    class Subticket < Sequel::Model(:subtickets)
-    end
+  class Subticket < Sequel::Model(:subtickets)
   end
 end

--- a/lib/tractive/model/ticket.rb
+++ b/lib/tractive/model/ticket.rb
@@ -1,6 +1,4 @@
 module Tractive
-  module Model
-    class Ticket < Sequel::Model(:ticket)
-    end
+  class Ticket < Sequel::Model(:ticket)
   end
 end

--- a/lib/tractive/trac.rb
+++ b/lib/tractive/trac.rb
@@ -5,11 +5,11 @@ module Tractive
     def initialize(db)
       $logger.info('loading tickets')
       @db          = db
-      @tickets     = Tractive::Model::Ticket
-      @subtickets  = Tractive::Model::Subticket
-      @changes     = Tractive::Model::Change
-      @sessions    = Tractive::Model::Session
-      @attachments = Tractive::Model::Attachment
+      @tickets     = Ticket
+      @subtickets  = Subticket
+      @changes     = Change
+      @sessions    = Session
+      @attachments = Attachment
     end
   end
 end


### PR DESCRIPTION
- Move functionality of `tractive-get-*-attachments` into proper `tractive` command
- Refactored models scopes


Resolves #7 