### PR TITLE
Generating revmap file

### DIFF
--- a/exe/tractive
+++ b/exe/tractive
@@ -26,6 +26,8 @@ class TractiveCommand < Thor
                               desc: "Local git repo path that should be used in revmap generation"
   class_option "revtimestampfile", type: :string, aliases: ["--rev-timestamp-file"],
                                    desc: "File containing svn revision and timestamps that should be used in revmap generation"
+  class_option "revoutfile", type: :string, aliases: ["--revmap-output-file"],
+                             desc: "File to output the generated revmap"
 
   class_option "filter", type: :boolean, aliases: ["-f", "--filter"],
                          desc: "Filter records that you want to import."

--- a/exe/tractive
+++ b/exe/tractive
@@ -18,7 +18,7 @@ class TractiveCommand < Thor
   class_option "fast", type: :boolean, aliases: ["-F", "--fast-import"],
                        desc: "Import without safety-checking issue numbers."
 
-  class_option "generaterevmap", type: :string, aliases: ["-G", "--generate-revmap"],
+  class_option "generaterevmap", type: :boolean, aliases: ["-G", "--generate-revmap"],
                                  desc: "Generate a mapping from svn revision number to git sha hash."
   class_option "svnurl", type: :string, aliases: ["--svn-url"],
                          desc: "Svn url that should be used in revmap generation"

--- a/exe/tractive
+++ b/exe/tractive
@@ -17,6 +17,16 @@ class TractiveCommand < Thor
                                     desc: "Export attachments from the database according to config.yaml"
   class_option "fast", type: :boolean, aliases: ["-F", "--fast-import"],
                        desc: "Import without safety-checking issue numbers."
+
+  class_option "generaterevmap", type: :string, aliases: ["-G", "--generate-revmap"],
+                                 desc: "Generate a mapping from svn revision number to git sha hash."
+  class_option "svnurl", type: :string, aliases: ["--svn-url"],
+                         desc: "Svn url that should be used in revmap generation"
+  class_option "gitrepopath", type: :string, aliases: ["--git-repo-path"],
+                              desc: "Local git repo path that should be used in revmap generation"
+  class_option "revtimestampfile", type: :string, aliases: ["--rev-timestamp-file"],
+                                   desc: "File containing svn revision and timestamps that should be used in revmap generation"
+
   class_option "filter", type: :boolean, aliases: ["-f", "--filter"],
                          desc: "Filter records that you want to import."
   class_option "columnname", type: :string, aliases: ["--column-name"],
@@ -25,6 +35,7 @@ class TractiveCommand < Thor
                            desc: "Operator for filter."
   class_option "columnvalue", type: :string, aliases: ["--column-value"],
                               desc: "Value of the column to filter."
+
   class_option "importfromfile", type: :string, aliases: ["-I", "--import-from-file"],
                                  desc: "Import issues from a json file"
   class_option "info", type: :boolean, aliases: ["-i", "--info"],

--- a/exe/tractive
+++ b/exe/tractive
@@ -22,8 +22,8 @@ class TractiveCommand < Thor
                                  desc: "Generate a mapping from svn revision number to git sha hash."
   class_option "svnurl", type: :string, aliases: ["--svn-url"],
                          desc: "Svn url that should be used in revmap generation"
-  class_option "gitrepopath", type: :string, aliases: ["--git-repo-path"],
-                              desc: "Local git repo path that should be used in revmap generation"
+  class_option "gitlocalrepopath", type: :string, aliases: ["--git-local-repo-path"],
+                                   desc: "Local git repo path that should be used in revmap generation"
   class_option "revtimestampfile", type: :string, aliases: ["--rev-timestamp-file"],
                                    desc: "File containing svn revision and timestamps that should be used in revmap generation"
   class_option "revoutfile", type: :string, aliases: ["--revmap-output-file"],

--- a/lib/tractive.rb
+++ b/lib/tractive.rb
@@ -9,6 +9,7 @@ require_relative "tractive/version"
 require_relative "tractive/main"
 require_relative "tractive/utilities"
 require_relative "tractive/github_api"
+require_relative "tractive/revmap_generator"
 require "json"
 require "logger"
 require "yaml"
@@ -20,6 +21,7 @@ require "singleton"
 require "uri"
 require "pry"
 require "thor"
+require "ox"
 
 module Tractive
   class Error < StandardError; end

--- a/lib/tractive/main.rb
+++ b/lib/tractive/main.rb
@@ -51,8 +51,8 @@ module Tractive
 
       Tractive::RevmapGenerator.new(
         @opts["svnurl"] || @cfg["svn_url"],
-        @opts["gitrepopath"] || @cfg["github"]["local_repo_path"],
-        @opts["revtimestampfile"] || @cfg["revtimestampfile"],
+        @opts["gitlocalrepopath"] || @cfg["github"]["local_repo_path"],
+        @opts["revtimestampfile"] || @cfg["rev_timestamp_file"],
         @opts["revoutfile"] || @cfg["revmap_output_file"]
       ).generate
     end
@@ -89,8 +89,8 @@ module Tractive
 
       required_options = {}
       required_options["--svn-url"] = options["svnurl"] || @cfg["svn_url"]
-      required_options["--git-repo-path"] = options["gitrepopath"] || @cfg["github"]["local_repo_path"]
-      required_options["--rev-timestamp-file"] = options["revtimestampfile"] || @cfg["revtimestampfile"]
+      required_options["--git-repo-path"] = options["gitlocalrepopath"] || @cfg["github"]["local_repo_path"]
+      required_options["--rev-timestamp-file"] = options["revtimestampfile"] || @cfg["rev_timestamp_file"]
 
       return if options.values.compact.empty?
 

--- a/lib/tractive/main.rb
+++ b/lib/tractive/main.rb
@@ -52,7 +52,8 @@ module Tractive
       Tractive::RevmapGenerator.new(
         @opts["svnurl"] || @cfg["svn_url"],
         @opts["gitrepopath"] || @cfg["github"]["local_repo_path"],
-        @opts["revtimestampfile"] || @cfg["revtimestampfile"]
+        @opts["revtimestampfile"] || @cfg["revtimestampfile"],
+        @opts["revoutfile"] || @cfg["revmap_output_file"]
       ).generate
     end
 

--- a/lib/tractive/main.rb
+++ b/lib/tractive/main.rb
@@ -22,6 +22,8 @@ module Tractive
         create_attachment_exporter_script
       elsif @opts[:exportattachments]
         export_attachments
+      elsif @opts[:generaterevmap]
+        generate_revmap_file
       else
         migrate
       end
@@ -41,6 +43,17 @@ module Tractive
 
     def create_attachment_exporter_script
       Tractive::AttachmentExporter.new(@cfg, @db).generate_script
+    end
+
+    def generate_revmap_file
+      # verfiry options and .fo file is present
+      verify_revmap_generator_options!(@opts)
+
+      Tractive::RevmapGenerator.new(
+        @opts["svnurl"] || @cfg["svn_url"],
+        @opts["gitrepopath"] || @cfg["github"]["local_repo_path"],
+        @opts["revtimestampfile"] || @cfg["revtimestampfile"]
+      ).generate
     end
 
     private
@@ -68,6 +81,19 @@ module Tractive
       return if !options[:filter] || missing_options.empty?
 
       warn_and_exit("missing filter options #{missing_options.values}", 1)
+    end
+
+    def verify_revmap_generator_options!(options)
+      return unless options[:generaterevmap]
+
+      required_options = {}
+      required_options["--svn-url"] = options["svnurl"] || @cfg["svn_url"]
+      required_options["--git-repo-path"] = options["gitrepopath"] || @cfg["github"]["local_repo_path"]
+      required_options["--rev-timestamp-file"] = options["revtimestampfile"] || @cfg["revtimestampfile"]
+
+      return if options.values.compact.empty?
+
+      warn_and_exit("missing revmap generator options (--svn-url, --git-repo-path, --rev-timestamp-file).\nProvide these options here or in the config file.", 1)
     end
 
     def warn_and_exit(message, exit_code)

--- a/lib/tractive/revmap_generator.rb
+++ b/lib/tractive/revmap_generator.rb
@@ -2,9 +2,9 @@
 
 module Tractive
   class RevmapGenerator
-    def initialize(input_file, svn_url, git_repo_path, output_file)
+    def initialize(input_file, svn_url, git_local_repo_path, output_file = "revmap.txt")
       @input_file = input_file
-      @git_repo_path = git_repo_path
+      @git_local_repo_path = git_local_repo_path
       @svn_url = svn_url
       @duplicate_commits = {}
       @duplicate_message_commits = {}
@@ -14,11 +14,11 @@ module Tractive
     end
 
     def generate
-      line_count = File.read("postfind.fo").scan(/\n/).count
+      line_count = File.read(@input_file).scan(/\n/).count
       i = 0
 
       File.open(@output_file, "w+") do |file|
-        File.foreach("postfind.fo") do |line|
+        File.foreach(@input_file) do |line|
           info = extract_info_from_line(line)
           next if @last_revision == info[:revision]
 
@@ -90,7 +90,7 @@ module Tractive
 
     def commits_from_git_repo(info)
       command = "git rev-list --after=#{info[:timestamp]} --until=#{info[:timestamp]} --committer=#{info[:author]} --all --format='%cd|%h~|~%s' --date=format:'%Y-%m-%dT%H:%M:%SZ'"
-      commits = Dir.chdir(@git_repo_path) do
+      commits = Dir.chdir(@git_local_repo_path) do
         `#{command}`
       end
 

--- a/lib/tractive/revmap_generator.rb
+++ b/lib/tractive/revmap_generator.rb
@@ -2,7 +2,7 @@
 
 module Tractive
   class RevmapGenerator
-    def initialize(input_file, svn_url, git_repo_path)
+    def initialize(input_file, svn_url, git_repo_path, output_file)
       @input_file = input_file
       @git_repo_path = git_repo_path
       @svn_url = svn_url
@@ -10,7 +10,7 @@ module Tractive
       @duplicate_message_commits = {}
       @last_revision = nil
       @pinwheel = %w[| / - \\]
-      @output_file = "revmap.txt"
+      @output_file = output_file
     end
 
     def generate

--- a/lib/tractive/revmap_generator.rb
+++ b/lib/tractive/revmap_generator.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Tractive
+  class RevmapGenerator
+    def initialize(input_file, svn_url, git_repo_path)
+      @input_file = input_file
+      @git_repo_path = git_repo_path
+      @svn_url = svn_url
+      @duplicate_commits = {}
+      @duplicate_message_commits = {}
+      @last_revision = nil
+      @pinwheel = %w[| / - \\]
+      @output_file = "revmap.txt"
+    end
+
+    def generate
+      line_count = File.read("postfind.fo").scan(/\n/).count
+      i = 0
+
+      File.open(@output_file, "w+") do |file|
+        File.foreach("postfind.fo") do |line|
+          info = extract_info_from_line(line)
+          next if @last_revision == info[:revision]
+
+          @last_revision = info[:revision]
+          print_revmap_info(info, file)
+
+          percent = ((i.to_f / line_count) * 100).round(2)
+          progress = "=" * (percent.to_i / 2) unless i < 2
+          printf("\rProgress: [%<progress>-50s] %<percent>.2f%% %<spinner>s", progress: progress, percent: percent, spinner: @pinwheel.rotate!.first)
+          i += 1
+        end
+      end
+    end
+
+    private
+
+    def extract_info_from_line(line)
+      info = {}
+
+      info[:revision], timestamp_author = line.split
+      info[:revision], info[:revision_count] = info[:revision].split(".")
+      info[:revision].gsub!("SVN:", "r")
+      info[:timestamp], author_count = timestamp_author.split("!")
+      info[:author], info[:count] = author_count.split(":")
+
+      info
+    end
+
+    def print_revmap_info(info, file)
+      # get sha from git api
+      commits = git_commits(info)
+
+      if commits.count == 1
+        file.puts "#{info[:revision]} | #{commits.values[0].join(",")}"
+      else
+        message = commit_message_from_svn(info[:revision])
+        file.puts "#{info[:revision]} | #{@duplicate_commits[info[:timestamp]][message].join(",")}"
+      end
+    end
+
+    def git_commits(info)
+      return @duplicate_commits[info[:timestamp]] if @duplicate_commits[info[:timestamp]]
+
+      # get commits from git dir
+      commits = commits_from_git_repo(info)
+
+      commits_hash = {}
+      commits.each do |commit|
+        message = commit[:message]
+        sha = commit[:sha]
+
+        if commits_hash[message]
+          commits_hash[message] << sha
+        else
+          commits_hash[message] = [sha]
+        end
+      end
+
+      @duplicate_commits[info[:timestamp]] = commits_hash if commits.count > 1
+
+      commits_hash
+    end
+
+    def commit_message_from_svn(revision)
+      svn_logs = Tractive::Utilities.svn_log(@svn_url, "-r": revision, "--xml": "")
+      h = Ox.load(svn_logs, mode: :hash)
+      h[:log][:logentry][3][:msg]
+    end
+
+    def commits_from_git_repo(info)
+      command = "git rev-list --after=#{info[:timestamp]} --until=#{info[:timestamp]} --committer=#{info[:author]} --all --format='%cd|%h~|~%s' --date=format:'%Y-%m-%dT%H:%M:%SZ'"
+      commits = Dir.chdir(@git_repo_path) do
+        `#{command}`
+      end
+
+      commits_arr = []
+      commits.split("\n").each_slice(2) do |sha_hash, commit_info|
+        commit_hash = {}
+        commit_hash[:sha] = sha_hash.split.last
+        commit_hash[:short_sha], commit_hash[:message] = commit_info.split("~|~")
+
+        commits_arr << commit_hash
+      end
+
+      commits_arr
+    end
+  end
+end

--- a/lib/tractive/utilities.rb
+++ b/lib/tractive/utilities.rb
@@ -45,6 +45,16 @@ module Tractive
           str
         end
       end
+
+      def svn_log(url, flags = {})
+        command = "svn log #{url}"
+        flags.each do |key, value|
+          command += " #{key}"
+          command += " #{value}" if value
+        end
+
+        `#{command}`
+      end
     end
   end
 end

--- a/spec/revmap_generator_spec.rb
+++ b/spec/revmap_generator_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+RSpec.describe Tractive::RevmapGenerator do
+  let(:revmap_generator) { Tractive::RevmapGenerator.new("abc.fo", "svn://dummy-url/myrepo", "/Users/someuser/somepath", "revmap.txt") }
+
+  context "#extract_info_from_line" do
+    it "should extract info from line without revision_count" do
+      line = "SVN:123 2021-12-21T21:21:21Z!foo@bar.com"
+      expected_hash = info_hash(
+        revision: "r123",
+        timestamp: "2021-12-21T21:21:21Z",
+        author: "foo@bar.com"
+      )
+      expect(revmap_generator.send(:extract_info_from_line, line)).to eq(expected_hash)
+    end
+  end
+
+  context "#git_commits" do
+    it "should return single commit" do
+      info = info_hash(
+        revision: "r123",
+        timestamp: "2021-12-21T21:21:21Z",
+        author: "foo@bar.com"
+      )
+
+      commits = [{ sha: "thisisalonglongsha", short_sha: "shortsha1", message: "demo message 1" }]
+      allow(revmap_generator).to receive(:commits_from_git_repo).with(info).and_return(commits)
+
+      expect(revmap_generator.send(:git_commits, info)).to eq({ "demo message 1" => ["thisisalonglongsha"] })
+    end
+
+    it "should populate @duplicate_commits" do
+      info = info_hash(
+        revision: "r123",
+        timestamp: "2021-12-21T21:21:21Z",
+        author: "foo@bar.com"
+      )
+
+      commits = [{ sha: "thisisalonglongsha1", short_sha: "shortsha1", message: "demo message 1" }, { sha: "thisisalonglongsha2", short_sha: "shortsha2", message: "demo message 2" }]
+      allow(revmap_generator).to receive(:commits_from_git_repo).with(info).and_return(commits)
+
+      expect(revmap_generator.send(:git_commits, info)).to eq({ "demo message 1" => ["thisisalonglongsha1"], "demo message 2" => ["thisisalonglongsha2"] })
+
+      expected_duplicate_commits = {
+        "2021-12-21T21:21:21Z" => {
+          "demo message 1" => ["thisisalonglongsha1"],
+          "demo message 2" => ["thisisalonglongsha2"]
+        }
+      }
+      expect(revmap_generator.instance_variable_get(:@duplicate_commits)).to eq(expected_duplicate_commits)
+    end
+
+    it "should use @duplicate_commits when present" do
+      info = info_hash(
+        revision: "r123",
+        timestamp: "2021-12-21T21:21:21Z",
+        author: "foo@bar.com"
+      )
+      duplicate_commits = {
+        "2021-12-21T21:21:21Z" => {
+          "demo message 1" => ["thisisalonglongsha1"],
+          "demo message 2" => ["thisisalonglongsha2"]
+        }
+      }
+      revmap_generator.instance_variable_set(:@duplicate_commits, duplicate_commits)
+      expect(revmap_generator.send(:git_commits, info)).to eq({ "demo message 1" => ["thisisalonglongsha1"], "demo message 2" => ["thisisalonglongsha2"] })
+    end
+  end
+
+  it "should generate correct revmap output for unique timestamps" do
+    buffer = StringIO.new
+    info = info_hash(revision: "r123", timestamp: "2021-12-21T21:21:21Z", author: "foo@bar.com")
+
+    allow(revmap_generator).to receive(:commits_from_git_repo).with(info).and_return([{ sha: "thisisalonglongsha", short_sha: "shortsha", message: "demo message 1" }])
+
+    revmap_generator.send(:print_revmap_info, info, buffer)
+
+    actual_string = buffer.string
+    expected_string = "r123 | thisisalonglongsha\n"
+    expect(actual_string).to eq(expected_string)
+  end
+
+  it "should generate correct revmap output for multiple revisions with same timestamp" do
+    buffer = StringIO.new
+    info1 = info_hash(revision: "r123", timestamp: "2021-12-21T21:21:21Z", author: "foo@bar.com")
+    info2 = info_hash(revision: "r124", timestamp: "2021-12-21T21:21:21Z", author: "foo@bar.com")
+
+    allow(revmap_generator).to receive(:commits_from_git_repo).with(info1).and_return([{ sha: "thisisalonglongsha1", short_sha: "shortsha1", message: "demo message 1" }, { sha: "thisisalonglongsha2", short_sha: "shortsha2", message: "demo message 2" }])
+
+    allow(revmap_generator).to receive(:commit_message_from_svn).with("r123").and_return("demo message 1")
+    allow(revmap_generator).to receive(:commit_message_from_svn).with("r124").and_return("demo message 2")
+
+    revmap_generator.send(:print_revmap_info, info1, buffer)
+    revmap_generator.send(:print_revmap_info, info2, buffer)
+
+    actual_string = buffer.string
+    expected_string = "r123 | thisisalonglongsha1\nr124 | thisisalonglongsha2\n"
+    expect(actual_string).to eq(expected_string)
+  end
+
+  it "should generate correct file for unique revisions" do
+    buffer = StringIO.new
+    info1 = info_hash(revision: "r123", timestamp: "2021-12-21T21:21:21Z", author: "foo@bar.com")
+    info2 = info_hash(revision: "r124", timestamp: "2021-12-21T22:22:22Z", author: "bar@baz.com")
+
+    allow(File).to receive(:open).with("revmap.txt", "w+").and_yield(buffer)
+    allow(File).to receive(:read).with("abc.fo").and_return("SVN:123 2021-12-21T21:21:21Z!foo@bar.com\nSVN:124 2021-12-21T22:22:22Z!bar@baz.com")
+    allow(File).to receive(:foreach).with("abc.fo").and_yield("SVN:123 2021-12-21T21:21:21Z!foo@bar.com").and_yield("SVN:124 2021-12-21T22:22:22Z!bar@baz.com")
+
+    allow(revmap_generator).to receive(:commits_from_git_repo).with(info1).and_return([{ sha: "thisisalonglongsha1", short_sha: "shortsha1", message: "demo message 1" }])
+    allow(revmap_generator).to receive(:commits_from_git_repo).with(info2).and_return([{ sha: "thisisalonglongsha2", short_sha: "shortsha2", message: "demo message 2" }])
+
+    revmap_generator.send(:generate)
+
+    actual_string = buffer.string
+    expected_string = "r123 | thisisalonglongsha1\nr124 | thisisalonglongsha2\n"
+    expect(actual_string).to eq(expected_string)
+  end
+
+  it "should generate correct file for multiple revisions with same timestamp" do
+    buffer = StringIO.new
+    info = info_hash(revision: "r123", timestamp: "2021-12-21T21:21:21Z", author: "foo@bar.com")
+
+    allow(File).to receive(:open).with("revmap.txt", "w+").and_yield(buffer)
+    allow(File).to receive(:read).with("abc.fo").and_return("SVN:123 2021-12-21T21:21:21Z!foo@bar.com\nSVN:124 2021-12-21T21:21:21Z!bar@baz.com")
+    allow(File).to receive(:foreach).with("abc.fo").and_yield("SVN:123 2021-12-21T21:21:21Z!foo@bar.com").and_yield("SVN:124 2021-12-21T21:21:21Z!bar@baz.com")
+
+    allow(revmap_generator).to receive(:commits_from_git_repo).with(info).and_return([{ sha: "thisisalonglongsha1", short_sha: "shortsha1", message: "demo message 1" }, { sha: "thisisalonglongsha2", short_sha: "shortsha2", message: "demo message 2" }])
+
+    allow(revmap_generator).to receive(:commit_message_from_svn).with("r123").and_return("demo message 1")
+    allow(revmap_generator).to receive(:commit_message_from_svn).with("r124").and_return("demo message 2")
+
+    revmap_generator.send(:generate)
+
+    actual_string = buffer.string
+    expected_string = "r123 | thisisalonglongsha1\nr124 | thisisalonglongsha2\n"
+    expect(actual_string).to eq(expected_string)
+  end
+
+  def info_hash(options = {})
+    {
+      revision: options[:revision],
+      revision_count: options[:revision_count],
+      timestamp: options[:timestamp],
+      count: options[:count],
+      author: options[:author]
+    }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,9 @@ RSpec.configure do |config|
     Tractive::Utilities.setup_db!(CONFIG["trac"]["database"])
   end
 
+  config.before(:all, &:silence_output)
+  config.after(:all,  &:enable_output)
+
   config.include Helpers::StubGitApi
   config.include Helpers::CommonFunctions
   config.include Helpers::TicketCompose
@@ -29,4 +32,25 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+end
+
+public
+
+# Redirects stderr and stout to /dev/null.txt
+def silence_output
+  # Store the original stderr and stdout in order to restore them later
+  @original_stderr = $stderr
+  @original_stdout = $stdout
+
+  # Redirect stderr and stdout
+  $stderr = File.new(File.join(File.dirname(__FILE__), "dev", "null.txt"), "w+")
+  $stdout = File.new(File.join(File.dirname(__FILE__), "dev", "null.txt"), "w+")
+end
+
+# Replace stderr and stdout so anything else is output correctly
+def enable_output
+  $stderr = @original_stderr
+  $stdout = @original_stdout
+  @original_stderr = nil
+  @original_stdout = nil
 end

--- a/tractive.gemspec
+++ b/tractive.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "mysql2"
+  spec.add_dependency "ox"
   spec.add_dependency "pry"
   spec.add_dependency "rest-client"
   spec.add_dependency "sequel"


### PR DESCRIPTION
`-G` option is added to generate `revmap` file. Three arguments are required to make the `revmap` file

1. `SVN URL` - It can be passed as a command-line argument with `--svn-url` or can be set in _config.yaml_ file by setting `svn_url`
2. `Local Git repo path` - It can be passed as a command-line argument with `--git-local-repo-path` or can be set in _config.yaml_ file by setting `github: local_repo_path`
3. `RevTimestampfile` - It can be passed as a command-line argument with `--rev-timestamp-file` or can be set in _config.yaml_ file by setting `rev_timestamp_file`
4. `Output file` - This is optional. It can be passed as a command line argument with `--revmap-output-file` or can be set in _config.yaml_ by setting `revmap_output_file`.

I ran this on the `ietfdb.fo` file generated by reposurgeon and got the following result -> [Revmap.txt](https://gist.github.com/HassanAkbar/791175886f42b79175205c5ee971b233)

Resolves ietf-ribose/svn-github-convert#19