### PR TITLE
bug fixes when commit msg blank in svn

### DIFF
--- a/exe/tractive
+++ b/exe/tractive
@@ -5,6 +5,8 @@ require_relative "../lib/tractive"
 
 class TractiveCommand < Thor
   default_command :migrate
+  class_option "logfile", type: :string, aliases: ["-L", "--log-file"],
+                          desc: "Name of the logfile to output logs to."
 
   desc "<OPTIONS>", "Migrate Trac instances to modern Git management platforms like GitHub and GitLab"
   method_option "attachmentexporter", type: :string, aliases: ["-A", "--attachment-exporter"],
@@ -33,8 +35,6 @@ class TractiveCommand < Thor
                                   desc: "Import issues from a json file"
   method_option "info", type: :boolean, aliases: ["-i", "--info"],
                         desc: "Reports existing labels and users in the database"
-  method_option "logfile", type: :string, aliases: ["-L", "--log-file"],
-                           desc: "Name of the logfile to output logs to."
   method_option "mockdeleted", type: :boolean, aliases: ["-M", "--mockup"],
                                desc: "Import from 0 and mocking tickets deleted on trac"
   method_option "openedonly", type: :boolean, aliases: ["-o", "--opened-only"],
@@ -64,6 +64,7 @@ class TractiveCommand < Thor
   def generate_revmap
     verify_revmap_generator_options!(options)
 
+    Tractive::Utilities.setup_logger(output_stream: options[:log_file] || $stderr, verbose: options[:verbose])
     Tractive::RevmapGenerator.new(
       options["revtimestampfile"],
       options["svnurl"],

--- a/lib/tractive/version.rb
+++ b/lib/tractive/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tractive
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
Fixed the following issues:
- Message comparison was not working properly because for long commit messages git split them into `title` and `body`.
- Tractive crashes when commit-msg was blank in svn (see attached image below).


<img width="607" alt="Screenshot 2021-10-12 at 8 07 06 PM" src="https://user-images.githubusercontent.com/5301572/136981815-6303d64e-c509-4ff7-9898-048444badb4f.png">
