### PR TITLE
Adding other changeset format

### DIFF
--- a/lib/tractive/migrator/converter/twf_to_markdown.rb
+++ b/lib/tractive/migrator/converter/twf_to_markdown.rb
@@ -95,7 +95,7 @@ module Migrator
         str.gsub!(/\[changeset:"(\d+)".*\]/) { Tractive::Utilities.map_changeset(Regexp.last_match[1], @revmap, changeset_base_url) }
         str.gsub!(/\[changeset:(\d+).*\]/) { Tractive::Utilities.map_changeset(Regexp.last_match[1], @revmap, changeset_base_url) }
         str.gsub!(/\[(\d+)\]/) { Tractive::Utilities.map_changeset(Regexp.last_match[1], @revmap, changeset_base_url) }
-        str.gsub!(/\[(\d+)\/.*\]/) { Tractive::Utilities.map_changeset(Regexp.last_match[1], @revmap, changeset_base_url) }
+        str.gsub!(%r{\[(\d+)/.*\]}) { Tractive::Utilities.map_changeset(Regexp.last_match[1], @revmap, changeset_base_url) }
       end
 
       # Font styles

--- a/lib/tractive/migrator/converter/twf_to_markdown.rb
+++ b/lib/tractive/migrator/converter/twf_to_markdown.rb
@@ -95,6 +95,7 @@ module Migrator
         str.gsub!(/\[changeset:"(\d+)".*\]/) { Tractive::Utilities.map_changeset(Regexp.last_match[1], @revmap, changeset_base_url) }
         str.gsub!(/\[changeset:(\d+).*\]/) { Tractive::Utilities.map_changeset(Regexp.last_match[1], @revmap, changeset_base_url) }
         str.gsub!(/\[(\d+)\]/) { Tractive::Utilities.map_changeset(Regexp.last_match[1], @revmap, changeset_base_url) }
+        str.gsub!(/\[(\d+)\/.*\]/) { Tractive::Utilities.map_changeset(Regexp.last_match[1], @revmap, changeset_base_url) }
       end
 
       # Font styles

--- a/lib/tractive/version.rb
+++ b/lib/tractive/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tractive
-  VERSION = "1.0.7"
+  VERSION = "1.0.8"
 end

--- a/spec/migrator/converter/twf_to_markdown_spec.rb
+++ b/spec/migrator/converter/twf_to_markdown_spec.rb
@@ -10,12 +10,15 @@ RSpec.describe Migrator::Converter::TwfToMarkdown do
 
     str1 = "Fixed in [1234]"
     str2 = "Fixed in [1234567]"
+    str3 = "Fixed in [1234/mailarch]"
 
     twf_to_markdown.send(:convert_changeset, str1, options_for_markdown_converter[:changeset_base_url])
     twf_to_markdown.send(:convert_changeset, str2, options_for_markdown_converter[:changeset_base_url])
+    twf_to_markdown.send(:convert_changeset, str3, options_for_markdown_converter[:changeset_base_url])
 
     expect(str1).to eq("Fixed in https://github.com/repo/commits/abcd123")
     expect(str2).to eq("Fixed in [1234567]")
+    expect(str3).to eq("Fixed in https://github.com/repo/commits/abcd123")
   end
 
   it "should convert ticket base url" do


### PR DESCRIPTION
- Added a fix for references like `[1234/mailarc]`

Fixed #61 