### PR TITLE
Attachment linkage and rendering

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,9 @@ Metrics/AbcSize:
 Metrics/MethodLength:
   Enabled: false
 
+Metrics/ModuleLength:
+  Max: 150
+
 Security/Open:
   Enabled: false
 

--- a/lib/tractive/migrator/converter/trac_to_github.rb
+++ b/lib/tractive/migrator/converter/trac_to_github.rb
@@ -288,7 +288,7 @@ module Migrator
           name = meta[:filename]
           body = meta[:description]
           if @attachurl
-            url = @uri_parser.escape("#{@attachurl}/#{attachment_path(meta[:id], name, meta[:type], @attachment_options)}")
+            url = @uri_parser.escape("#{@attachurl}/#{attachment_path(meta[:id], name, @attachment_options)}")
             text += "[`#{name}`](#{url})"
             body += "\n![#{name}](#{url})" if [".png", ".jpg", ".gif"].include? File.extname(name).downcase
           else
@@ -341,7 +341,7 @@ module Migrator
         "[trac:#{ticket[:id]}](#{@tracticketbaseurl}/#{ticket[:id]})"
       end
 
-      def attachment_path(id, filename, type, options = {})
+      def attachment_path(id, filename, options = {})
         return "#{id}/#{filename}" unless options[:hashed]
 
         folder_name = Digest::SHA1.hexdigest(id)
@@ -349,7 +349,7 @@ module Migrator
         hashed_filename = Digest::SHA1.hexdigest(filename)
         file_extension = File.extname(filename)
 
-        "#{type}/#{parent_folder_name}/#{folder_name}/#{hashed_filename}#{file_extension}"
+        "#{parent_folder_name}/#{folder_name}/#{hashed_filename}#{file_extension}"
       end
     end
   end

--- a/spec/files/test.config.yaml
+++ b/spec/files/test.config.yaml
@@ -732,3 +732,7 @@ labels:
     closed:
       name: closed
       color:
+
+attachments:
+  url: http://www.abc.com/test
+  hashed: true

--- a/spec/files/test.config.yaml
+++ b/spec/files/test.config.yaml
@@ -734,5 +734,5 @@ labels:
       color:
 
 attachments:
-  url: http://www.abc.com/test
+  url: http://www.abc.com/test/ticket
   hashed: true

--- a/spec/migrator/converter/trac_to_github_spec.rb
+++ b/spec/migrator/converter/trac_to_github_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe Migrator::Converter::TracToGithub do
     stub_milestone_request
     stub_get_labels_request
     stub_create_labels_request
+
+    time_now = Time.now
+    allow(Time).to receive(:now).and_return(time_now)
   end
 
   it "compose correct issue" do
@@ -34,6 +37,16 @@ RSpec.describe Migrator::Converter::TracToGithub do
 
     actual_ticket_hash = Migrator::Converter::TracToGithub.new(options_for_migrator(singlepost: true)).compose(ticket)
     expected_ticket_hash = ticket_compose_hash_with_singlepost(ticket)
+
+    expect(actual_ticket_hash["issue"]).to eq(expected_ticket_hash["issue"])
+    expect(actual_ticket_hash["comments"]).to match_array(expected_ticket_hash["comments"])
+  end
+
+  it "compose correct issue with attachments as hashed values" do
+    ticket = Tractive::Ticket.find(id: 872)
+
+    actual_ticket_hash = Migrator::Converter::TracToGithub.new(options_for_migrator).compose(ticket)
+    expected_ticket_hash = ticket_compose_hash872(ticket)
 
     expect(actual_ticket_hash["issue"]).to eq(expected_ticket_hash["issue"])
     expect(actual_ticket_hash["comments"]).to match_array(expected_ticket_hash["comments"])

--- a/spec/support/helpers/ticket_compose.rb
+++ b/spec/support/helpers/ticket_compose.rb
@@ -103,5 +103,31 @@ module Helpers
         }
       }
     end
+
+    def ticket_compose_hash872(ticket)
+      changes = ticket.all_changes
+      changes = changes.reject do |c|
+        !c.is_a?(Tractive::Attachment) && (%w[keywords cc reporter version].include?(c.field) ||
+          (c.field == "comment" && (c.newvalue.nil? || c.newvalue.lstrip.empty?)))
+      end
+
+      {
+        "issue" => {
+          "title" => "Discusses page has documents with only ex-AD DISCUSSes",
+          "body" => "`type_defect`   |    by presnick@qualcomm.com\n\n___\n\n\nhttps://datatracker.ietf.org/iesg/discusses/ lists documents where the only DISCUSS holder are retired ADs. It should not have those documents listed.\n\n___\n_Issue migrated from trac:872 at #{Time.now}_",
+          "labels" => ["medium", "accepted", "component: doc/"],
+          "closed" => false,
+          "created_at" => format_time(ticket[:time]),
+          "milestone" => nil,
+          "assignee" => nil
+        },
+        "comments" => [
+          { "body" => "_@vidyut.luther@neustar.biz_ _uploaded file [`settings.py`](http://www.abc.com/test/ticket/389/389b4f6ee5bd60bebd9d0708da23ba8b4134620b/888c15d72e41c9f0f1882f4aea4c2d19f1a044eb.py) (4.9 KiB)_\n\nExisting settings.py in production right now.", "created_at" => format_time(changes[0][:time]) },
+          { "body" => "_@henrik@levkowetz.com_ _changed priority from `minor` to `medium`_", "created_at" => format_time(changes[1][:time]) },
+          { "body" => "_@rjsparks@nostrum.com_ _commented_\n\n\n___\nI've taken several runs at improving this since it was reported. I've been lured by the siren to fix the query rather than fix this particular page's output. It turns out that a query for what this page should show that is both correct and efficient is very hard (perhaps not possible). Instead, we should replumb the page so that we have a chance to remove the set of offending documents from the list being displayed after we've run the query. If it's not done before then, I'll take another run at the next sprint. ", "created_at" => format_time(changes[2][:time]) },
+          { "body" => "_@rjsparks@nostrum.com_ _changed status from `new` to `accepted`_", "created_at" => format_time(changes[3][:time]) }
+        ]
+      }
+    end
   end
 end


### PR DESCRIPTION
- Added an option in config file to tell if the image names are hashed or not like in trac storage.

For this we need to place the images in a public repo. I have created a [public repo](https://github.com/hassanakbar4/attachments) in my account and added all the images there for test purpose. Here is an example:

![image link](https://raw.githubusercontent.com/hassanakbar4/attachments/main/ticket/1a1/1a1162ec85b1d21244d7d3ecba5bc65878b73777/ed18eed70cd86197fd6fa79cdca15df03dbeda40.png)

Fixes https://github.com/ietf-ribose/svn-github-convert/issues/46