### PR TITLE
Adding orignal closed_at to issues

### DIFF
--- a/lib/tractive/migrator/converter/trac_to_github.rb
+++ b/lib/tractive/migrator/converter/trac_to_github.rb
@@ -4,7 +4,7 @@ module Migrator
   module Converter
     class TracToGithub
       def initialize(args)
-        @trac_ticket_base_url    = args[:cfg]["trac"]["ticketbaseurl"]
+        @trac_ticket_base_url = args[:cfg]["trac"]["ticketbaseurl"]
         @attachurl            = args[:opts][:attachurl] || args[:cfg].dig("ticket", "attachments", "url")
         @changeset_base_url   = args[:cfg]["trac"]["changeset_base_url"] || ""
         @singlepost           = args[:opts][:singlepost]

--- a/lib/tractive/migrator/converter/trac_to_github.rb
+++ b/lib/tractive/migrator/converter/trac_to_github.rb
@@ -4,7 +4,7 @@ module Migrator
   module Converter
     class TracToGithub
       def initialize(args)
-        @tracticketbaseurl    = args[:cfg]["trac"]["ticketbaseurl"]
+        @trac_ticket_base_url    = args[:cfg]["trac"]["ticketbaseurl"]
         @attachurl            = args[:opts][:attachurl] || args[:cfg].dig("ticket", "attachments", "url")
         @changeset_base_url   = args[:cfg]["trac"]["changeset_base_url"] || ""
         @singlepost           = args[:opts][:singlepost]
@@ -29,7 +29,7 @@ module Migrator
 
         @uri_parser = URI::Parser.new
         @twf_to_markdown = Migrator::Converter::TwfToMarkdown.new(
-          @tracticketbaseurl,
+          @trac_ticket_base_url,
           @attachment_options,
           @changeset_base_url,
           @wiki_attachments_url,
@@ -80,7 +80,7 @@ module Migrator
           @labels_cfg.fetch(x[:field], {})[x[:newvalue]]
           labels.delete(del) if del
           # labels.add(add) if add
-          closed_time = x[:time] if (x[:field] == "status") && (x[:newvalue] == "closed")
+          closed_time = x[:time] if x[:field] == "status" && x[:newvalue] == "closed"
         end
 
         # we separate labels from badges
@@ -349,9 +349,9 @@ module Migrator
       end
 
       def trac_ticket_link(ticket)
-        return "trac:#{ticket[:id]}" unless @tracticketbaseurl
+        return "trac:#{ticket[:id]}" unless @trac_ticket_base_url
 
-        "[trac:#{ticket[:id]}](#{@tracticketbaseurl}/#{ticket[:id]})"
+        "[trac:#{ticket[:id]}](#{@trac_ticket_base_url}/#{ticket[:id]})"
       end
     end
   end

--- a/lib/tractive/migrator/engine.rb
+++ b/lib/tractive/migrator/engine.rb
@@ -96,7 +96,7 @@ module Migrator
 
     def mock_ticket_details(ticket_id)
       summary = if @filter_applied
-                  "Not available in trac #{ticket_id}"
+                  "Placeholder issue #{ticket_id} created to align github issue and trac ticket numbers during migration."
                 else
                   "DELETED in trac #{ticket_id}"
                 end
@@ -105,7 +105,8 @@ module Migrator
         summary: summary,
         time: Time.now.to_i,
         status: "closed",
-        reporter: "tractive"
+        reporter: "tractive",
+        closed_at: Time.at(0).utc
       }
     end
 

--- a/lib/tractive/migrator/engine.rb
+++ b/lib/tractive/migrator/engine.rb
@@ -96,7 +96,7 @@ module Migrator
 
     def mock_ticket_details(ticket_id)
       summary = if @filter_applied
-                  "Placeholder issue #{ticket_id} created to align github issue and trac ticket numbers during migration."
+                  "Placeholder issue #{ticket_id} created to align Github issue and trac ticket numbers during migration."
                 else
                   "DELETED in trac #{ticket_id}"
                 end

--- a/lib/tractive/models/ticket.rb
+++ b/lib/tractive/models/ticket.rb
@@ -39,5 +39,9 @@ module Tractive
       change_arr = changes + attachments
       change_arr.sort_by { |change| change[:time] }
     end
+
+    def closed_comments
+      changes_dataset.where(field: "status", newvalue: "closed")
+    end
   end
 end

--- a/spec/migrator/engine_spec.rb
+++ b/spec/migrator/engine_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Migrator::Engine do
   it "should compose correct mock ticket when filtering" do
     mock_ticket = Migrator::Engine.new(options_for_migrator(filter: true)).send(:mock_ticket_details, 1)
 
-    expect(mock_ticket[:summary]).to eq("Not available in trac 1")
+    expect(mock_ticket[:summary]).to eq("Placeholder issue 1 created to align github issue and trac ticket numbers during migration.")
   end
 
   it "should generate correct comment body" do

--- a/spec/migrator/engine_spec.rb
+++ b/spec/migrator/engine_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Migrator::Engine do
   it "should compose correct mock ticket when filtering" do
     mock_ticket = Migrator::Engine.new(options_for_migrator(filter: true)).send(:mock_ticket_details, 1)
 
-    expect(mock_ticket[:summary]).to eq("Placeholder issue 1 created to align github issue and trac ticket numbers during migration.")
+    expect(mock_ticket[:summary]).to eq("Placeholder issue 1 created to align Github issue and trac ticket numbers during migration.")
   end
 
   it "should generate correct comment body" do

--- a/spec/support/helpers/ticket_compose.rb
+++ b/spec/support/helpers/ticket_compose.rb
@@ -10,6 +10,7 @@ module Helpers
             "body" => "`resolution_wontfix` `type_task`   |    by henrik@levkowetz.com\n\n___\n\n___\n_@henrik@levkowetz.com_ _changed milestone from `2.02` to ``_\n\n___\n_@henrik@levkowetz.com_ _changed milestone from `` to `Soonish`_\n\n___\n_@pasi.eronen@nokia.com_ _changed status from `new` to `closed`_\n\n___\n_@pasi.eronen@nokia.com_ _set resolution to `wontfix`_\n\n___\n_@pasi.eronen@nokia.com_ _commented_\n\nWe're not currently using buildbot -- will close the ticket.\n\n___\n_Issue migrated from trac:170 at #{Time.now}_",
             "labels" => ["n/a", "closed", "component: Datatracker: Testing"],
             "closed" => true,
+            "closed_at" => "2009-11-03T01:50:22Z",
             "created_at" => format_time(ticket[:time]),
             "milestone" => nil,
             "assignee" => nil
@@ -32,6 +33,7 @@ module Helpers
           "body" => "`resolution_fixed` `type_task`   |    by henrik@levkowetz.com\n\n___\n\n\n\n\n___\n_Issue migrated from trac:3 at #{Time.now}_",
           "labels" => ["n/a", "closed", "component: admin/", "owner:henrik@levkowetz.com"],
           "closed" => true,
+          "closed_at" => "2007-06-28T19:12:15Z",
           "created_at" => format_time(ticket[:time]),
           "milestone" => nil,
           "assignee" => "henrik@levkowetz.com"
@@ -98,6 +100,7 @@ module Helpers
           "body" => "`resolution_fixed` `type_cleanup`   |    by fenner@research.att.com\n\n___\n\n\nI noticed two problems while trying to validate my Related Documents tool:\n\n1. There are duplicate entries for three RFCs in internet_drafts.  This requires some research to resolve, since it's not completely clear which one is the proper value.  I started to add the following to sql_fixup.sql, but stopped because I didn't want to research what was right:\n\n```\n--\n-- There were duplicates for the rfc_number field.\n-- Since an RFC can only come from a single I-D, there are\n-- various places where the code has this assumption.\n-- The cgi stuff would just get an inconsistent result\n-- in this case, but the django stuff will throw an exception.\n-- So we fix up the cases that we know about, and we make\n-- the RFC number field UNIQUE so that the database won't let\n-- it happen again.\n-- In order for this to work, rfc_number has to be NULL to flag\n-- \"no rfc\", not 0.\nUPDATE internet_drafts SET rfc_number=NULL WHERE rfc_number=0;\n\n-- 1707\n\n-- 1861\n\n-- 2358\nUPDATE internet_drafts SET replaced_by=1764, rfc_number=NULL where id_document_tag=824;\n\nALTER TABLE  `internet_drafts` ADD UNIQUE (`rfc_number`);\n```\n\n2. There are RFCs referred to in internet_drafts that are not in the rfcs table.\n\n```\nmysql> select id_document_tag,a.rfc_number\n from internet_drafts a\n left join rfcs on a.rfc_number = rfcs.rfc_number\n where a.rfc_number != 0\n     and rfcs.rfc_number is null;\n+-----------------+------------+\n| id_document_tag | rfc_number |\n+-----------------+------------+\n|            2977 |       2498 |\n|            4611 |       2873 |\n+-----------------+------------+\n2 rows in set (0.10 sec)\n```\n\nThe easy answer here is to add the corresponding rows for RFCs 2498 and 2873 to the `rfcs` database.\n\n___\n_Issue migrated from trac:98 at #{Time.now}_",
           "labels" => ["n/a", "closed", "component: Datatracker: Base templates"],
           "closed" => true,
+          "closed_at" => "2010-03-24T23:35:17Z",
           "created_at" => format_time(ticket[:time]),
           "milestone" => nil
         }

--- a/spec/support/helpers/ticket_compose.rb
+++ b/spec/support/helpers/ticket_compose.rb
@@ -10,7 +10,7 @@ module Helpers
             "body" => "`resolution_wontfix` `type_task`   |    by henrik@levkowetz.com\n\n___\n\n___\n_@henrik@levkowetz.com_ _changed milestone from `2.02` to ``_\n\n___\n_@henrik@levkowetz.com_ _changed milestone from `` to `Soonish`_\n\n___\n_@pasi.eronen@nokia.com_ _changed status from `new` to `closed`_\n\n___\n_@pasi.eronen@nokia.com_ _set resolution to `wontfix`_\n\n___\n_@pasi.eronen@nokia.com_ _commented_\n\nWe're not currently using buildbot -- will close the ticket.\n\n___\n_Issue migrated from trac:170 at #{Time.now}_",
             "labels" => ["n/a", "closed", "component: Datatracker: Testing"],
             "closed" => true,
-            "closed_at" => "2009-11-03T01:50:22Z",
+            "closed_at" => format_time(ticket.closed_comments.order(:time).last.time),
             "created_at" => format_time(ticket[:time]),
             "milestone" => nil,
             "assignee" => nil
@@ -33,7 +33,7 @@ module Helpers
           "body" => "`resolution_fixed` `type_task`   |    by henrik@levkowetz.com\n\n___\n\n\n\n\n___\n_Issue migrated from trac:3 at #{Time.now}_",
           "labels" => ["n/a", "closed", "component: admin/", "owner:henrik@levkowetz.com"],
           "closed" => true,
-          "closed_at" => "2007-06-28T19:12:15Z",
+          "closed_at" => format_time(ticket.closed_comments.order(:time).last.time),
           "created_at" => format_time(ticket[:time]),
           "milestone" => nil,
           "assignee" => "henrik@levkowetz.com"
@@ -100,7 +100,7 @@ module Helpers
           "body" => "`resolution_fixed` `type_cleanup`   |    by fenner@research.att.com\n\n___\n\n\nI noticed two problems while trying to validate my Related Documents tool:\n\n1. There are duplicate entries for three RFCs in internet_drafts.  This requires some research to resolve, since it's not completely clear which one is the proper value.  I started to add the following to sql_fixup.sql, but stopped because I didn't want to research what was right:\n\n```\n--\n-- There were duplicates for the rfc_number field.\n-- Since an RFC can only come from a single I-D, there are\n-- various places where the code has this assumption.\n-- The cgi stuff would just get an inconsistent result\n-- in this case, but the django stuff will throw an exception.\n-- So we fix up the cases that we know about, and we make\n-- the RFC number field UNIQUE so that the database won't let\n-- it happen again.\n-- In order for this to work, rfc_number has to be NULL to flag\n-- \"no rfc\", not 0.\nUPDATE internet_drafts SET rfc_number=NULL WHERE rfc_number=0;\n\n-- 1707\n\n-- 1861\n\n-- 2358\nUPDATE internet_drafts SET replaced_by=1764, rfc_number=NULL where id_document_tag=824;\n\nALTER TABLE  `internet_drafts` ADD UNIQUE (`rfc_number`);\n```\n\n2. There are RFCs referred to in internet_drafts that are not in the rfcs table.\n\n```\nmysql> select id_document_tag,a.rfc_number\n from internet_drafts a\n left join rfcs on a.rfc_number = rfcs.rfc_number\n where a.rfc_number != 0\n     and rfcs.rfc_number is null;\n+-----------------+------------+\n| id_document_tag | rfc_number |\n+-----------------+------------+\n|            2977 |       2498 |\n|            4611 |       2873 |\n+-----------------+------------+\n2 rows in set (0.10 sec)\n```\n\nThe easy answer here is to add the corresponding rows for RFCs 2498 and 2873 to the `rfcs` database.\n\n___\n_Issue migrated from trac:98 at #{Time.now}_",
           "labels" => ["n/a", "closed", "component: Datatracker: Base templates"],
           "closed" => true,
-          "closed_at" => "2010-03-24T23:35:17Z",
+          "closed_at" => format_time(ticket.closed_comments.order(:time).last.time),
           "created_at" => format_time(ticket[:time]),
           "milestone" => nil
         }


### PR DESCRIPTION
- Add actual closed at time to issues
- For mocked issues use oldest date possible
- Change placeholder issue description to `Placeholder issue #{ticket_id} created to align github issue and trac ticket numbers during migration.`

Resolves #68 