### PR TITLE
convert html and comment tags

### DIFF
--- a/lib/tractive/migrator/converter/twf_to_markdown.rb
+++ b/lib/tractive/migrator/converter/twf_to_markdown.rb
@@ -82,7 +82,7 @@ module Migrator
         str.gsub!(/\{\{\{#!comment([\s|\n])(.*?)\}\}\}/m, '<!--\1\2\1-->')
       end
 
-      # Comments
+      # HTML Snippets
       def convert_html_snippets(str)
         str.gsub!(/\{\{\{#!html(.*?)\}\}\}/m, '\1')
       end

--- a/spec/migrator/converter/twf_to_markdown_spec.rb
+++ b/spec/migrator/converter/twf_to_markdown_spec.rb
@@ -58,6 +58,43 @@ RSpec.describe Migrator::Converter::TwfToMarkdown do
     expect(str).to eq("foo \n bar \n baz \n")
   end
 
+  it "should convert comments" do
+    str1 = "{{{#!comment this is a comment}}}"
+    str2 = <<~WIKI_COMMENT_TEXT
+      {{{#!comment
+      this is a comment
+      }}}
+    WIKI_COMMENT_TEXT
+
+    twf_to_markdown.send(:convert_comments, str1)
+    twf_to_markdown.send(:convert_comments, str2)
+
+    expect(str1).to eq("<!-- this is a comment -->")
+    expect(str2).to eq("<!--\nthis is a comment\n\n-->\n")
+  end
+
+  it "should convert html snippets" do
+    str = <<~WIKI_HTML_SNIPPET
+      {{{#!html
+      <h1 style="text-align: right; color: blue">
+        HTML Test
+      </h1>
+      }}}
+    WIKI_HTML_SNIPPET
+
+    expected_str = <<~MARKDOWN_HTML_SNIPPET
+
+      <h1 style="text-align: right; color: blue">
+        HTML Test
+      </h1>
+
+    MARKDOWN_HTML_SNIPPET
+
+    twf_to_markdown.send(:convert_html_snippets, str)
+
+    expect(str).to eq(expected_str)
+  end
+
   it "should convert code snippets" do
     str = "{{{single line code}}} \n {{{ multiline \n code }}}"
 
@@ -68,7 +105,7 @@ RSpec.describe Migrator::Converter::TwfToMarkdown do
 
   it "should convert font styles" do
     bold = "'''bold'''"
-    italic = "''italic''  //italic//"
+    italic = "''italic'' //italic//"
 
     twf_to_markdown.send(:convert_font_styles, bold)
     twf_to_markdown.send(:convert_font_styles, italic)
@@ -100,9 +137,138 @@ RSpec.describe Migrator::Converter::TwfToMarkdown do
     twf_to_markdown.send(:convert_image, img3, base_url, attach_url, wiki_attachments_url)
     twf_to_markdown.send(:convert_image, img4, base_url, attach_url, wiki_attachments_url)
 
+    twf_to_markdown.send(:revert_image_references, img1)
+    twf_to_markdown.send(:revert_image_references, img2)
+    twf_to_markdown.send(:revert_image_references, img3)
+    twf_to_markdown.send(:revert_image_references, img4)
+
     expect(img1).to eq("This is an image ![https://google/image/1](https://google/image/1)")
     expect(img2).to eq("![ticket:1:picture.png](#{attach_url}/1/picture.png)")
     expect(img3).to eq("![picture.png](#{wiki_attachments_url}/WikiFormatting/picture.png)")
     expect(img4).to eq("![trac_logo_mini.png](#{base_url}/trunk/trac/htdocs/trac_logo_mini.png)")
+  end
+
+  it "should convert from trak wiki format to github markdown format" do
+    str = <<~WIKI_FORMAT_TEXT
+      Some ticket references:
+      - Fixed in [1234]
+      - Fixed in [1234/mailarch]
+
+      Ticket references:
+      - https://foo.bar/trac/foobar/ticket/123
+      - ticket:123
+
+      Headings:
+      = h1 =
+      == h2 ==
+      === h3 ===
+      ==== h4 ====
+      ===== h5 =====
+      ====== h6 ======
+
+      New lines formatters:
+      foo [[br]] bar \r\n baz [[BR]]
+
+      Comments:
+      - {{{#!comment This is a single line comment}}}
+      - {{{#!comment
+          This is a multiline comment
+        }}}
+
+      Html Snippet:
+      {{{#!html
+      <h1 style="text-align: right; color: blue">
+        HTML Test
+      </h1>
+      }}}
+
+      Code Snippets:
+      - {{{single line code}}}
+      - {{{
+          multiline
+          code
+        }}}
+
+      Font Styles:
+      - '''bold'''
+      - ''italic''
+      - //italic//
+
+      External Links:
+      - [https://www.google.com google engine]
+
+      Here are some images:
+      - [[Image(https://google/image/1)]]
+      - [[Image(ticket:1:picture.png)]]
+      - [[Image(wiki:WikiFormatting:picture.png)]]
+      - [[Image(source:/trunk/trac/htdocs/trac_logo_mini.png)]]
+    WIKI_FORMAT_TEXT
+
+    base_url = options_for_markdown_converter[:base_url]
+    attach_url = options_for_markdown_converter[:attachment_options][:url]
+    wiki_attachments_url = options_for_markdown_converter[:wiki_attachments_url]
+
+    expected_str = <<~MARKDOWN_FORMAT_TEXT
+      Some ticket references:
+      - Fixed in https://github.com/repo/commits/abcd123
+      - Fixed in https://github.com/repo/commits/abcd123
+
+      Ticket references:
+      - #123
+      - #123
+
+      Headings:
+      # h1
+      ## h2
+      ### h3
+      #### h4
+      ##### h5
+      ###### h6
+
+      New lines formatters:
+      foo\s
+       bar\s
+       baz\s
+
+
+      Comments:
+      - <!-- This is a single line comment -->
+      - <!--
+          This is a multiline comment
+      \s\s
+      -->
+
+      Html Snippet:
+
+      <h1 style="text-align: right; color: blue">
+        HTML Test
+      </h1>
+
+
+      Code Snippets:
+      - `single line code`
+      - ```
+          multiline
+          code
+        ```
+
+      Font Styles:
+      - **bold**
+      - *italic*
+      - _italic_
+
+      External Links:
+      - [google engine](https://www.google.com)
+
+      Here are some images:
+      - ![https://google/image/1](https://google/image/1)
+      - ![ticket:1:picture.png](#{attach_url}/1/picture.png)
+      - ![picture.png](#{wiki_attachments_url}/WikiFormatting/picture.png)
+      - ![trac_logo_mini.png](#{base_url}/trunk/trac/htdocs/trac_logo_mini.png)
+    MARKDOWN_FORMAT_TEXT
+
+    twf_to_markdown.convert(str)
+
+    expect(str).to eq(expected_str)
   end
 end


### PR DESCRIPTION
Convert WikiMedia commands `#!html` and `#!comment` to Github flavored markdown.

Closes #76 