### PR TITLE
Converting owner tags to labels

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,7 +36,7 @@ Metrics/MethodLength:
   Enabled: false
 
 Metrics/ModuleLength:
-  Max: 150
+  Max: 250
 
 Metrics/ParameterLists:
   Max: 6

--- a/exe/tractive
+++ b/exe/tractive
@@ -47,6 +47,8 @@ class TractiveCommand < CommandBase
                               desc: "Put all issue comments in the first message."
   method_option "start", type: :numeric, aliases: ["-s", "--start-at"], banner: "<ID>",
                          desc: "Start migration from ticket with number <ID>"
+  method_option "make-owners-labels", type: :boolean,
+                                      desc: "If true, this will make a tag like `owner:<owner name>` and add it to the issue."
   def migrate_tickets
     Tractive::Main.new(options).run
   end

--- a/lib/tractive/migrator/converter/trac_to_github.rb
+++ b/lib/tractive/migrator/converter/trac_to_github.rb
@@ -16,6 +16,7 @@ module Migrator
         @client               = GithubApi::Client.new(access_token: args[:cfg]["github"]["token"])
         @wiki_attachments_url = args[:cfg].dig("wiki", "attachments", "url")
         @revmap_file_path     = args[:opts][:revmapfile] || args[:cfg]["revmap_path"]
+        @make_owners_label    = args[:opts]["make-owners-labels"] || args[:cfg]["make_owners_labels"]
         @attachment_options   = {
           url: @attachurl,
           hashed: args[:cfg].dig("ticket", "attachments", "hashed")
@@ -121,6 +122,12 @@ module Migrator
 
         github_assignee = map_assignee(ticket[:owner])
 
+        if @make_owners_label
+          labels.add("name" => "owner:#{github_assignee}") unless github_assignee.nil? || github_assignee.empty?
+        else
+          badges.add("owner:#{github_assignee}")
+        end
+
         badges     = badges.to_a.compact.sort
         badgetable = badges.map { |i| %(`#{i}`) }.join(" ")
         badgetable += begin
@@ -132,8 +139,6 @@ module Migrator
 
         # compose body
         body = [badgetable, body, footer].join("\n\n___\n")
-
-        labels.add("name" => "owner:#{github_assignee}") unless github_assignee.nil? || github_assignee.empty?
         labels = labels.map { |label| label["name"] }
 
         issue = {

--- a/lib/tractive/migrator/converter/trac_to_github.rb
+++ b/lib/tractive/migrator/converter/trac_to_github.rb
@@ -122,10 +122,12 @@ module Migrator
 
         github_assignee = map_assignee(ticket[:owner])
 
-        if @make_owners_label
-          labels.add("name" => "owner:#{github_assignee}") unless github_assignee.nil? || github_assignee.empty?
-        else
-          badges.add("owner:#{github_assignee}")
+        unless github_assignee.nil? || github_assignee.empty?
+          if @make_owners_label
+            labels.add("name" => "owner:#{github_assignee}")
+          else
+            badges.add("owner:#{github_assignee}")
+          end
         end
 
         badges     = badges.to_a.compact.sort

--- a/spec/migrator/converter/trac_to_github_spec.rb
+++ b/spec/migrator/converter/trac_to_github_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe Migrator::Converter::TracToGithub do
     expect(actual_ticket_hash["comments"]).to match_array(expected_ticket_hash["comments"])
   end
 
+  it "compose correct issue without owners as labels" do
+    ticket = Tractive::Ticket.find(id: 3)
+
+    actual_ticket_hash = Migrator::Converter::TracToGithub.new(options_for_migrator).compose(ticket)
+    expected_ticket_hash = ticket_compose_hash3_without_owner_label(ticket)
+
+    expect(actual_ticket_hash["issue"]).to eq(expected_ticket_hash["issue"])
+    expect(actual_ticket_hash["comments"]).to match_array(expected_ticket_hash["comments"])
+  end
+
   it "compose correct issue without assignee" do
     ticket = Tractive::Ticket.find(id: 98)
 

--- a/spec/migrator/converter/trac_to_github_spec.rb
+++ b/spec/migrator/converter/trac_to_github_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Migrator::Converter::TracToGithub do
   it "compose correct issue" do
     ticket = Tractive::Ticket.find(id: 3)
 
-    actual_ticket_hash = Migrator::Converter::TracToGithub.new(options_for_migrator).compose(ticket)
+    actual_ticket_hash = Migrator::Converter::TracToGithub.new(options_for_migrator("make-owners-labels" => true)).compose(ticket)
     expected_ticket_hash = ticket_compose_hash3(ticket)
 
     expect(actual_ticket_hash["issue"]).to eq(expected_ticket_hash["issue"])

--- a/spec/migrator/engine_spec.rb
+++ b/spec/migrator/engine_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Migrator::Engine do
     allow(File).to receive(:new).with(filename, "w+").and_return(buffer)
 
     converter = Migrator::Converter::TracToGithub.new(options_for_migrator)
-    migrator = Migrator::Engine.new(options_for_migrator(dryrun: true, filter: true, columnname: "id", operator: "<", columnvalue: "4"))
+    migrator = Migrator::Engine.new(options_for_migrator(dryrun: true, filter: true, columnname: "id", operator: "<", columnvalue: "4", "make-owners-labels" => true))
     migrator.migrate
 
     actual_hash = JSON.parse(buffer.string)

--- a/spec/support/helpers/ticket_compose.rb
+++ b/spec/support/helpers/ticket_compose.rb
@@ -69,6 +69,55 @@ module Helpers
       }
     end
 
+    def ticket_compose_hash3_without_owner_label(ticket)
+      changes = ticket.all_changes
+      changes = changes.reject do |c|
+        %w[keywords cc reporter version].include?(c.field) ||
+          (c.field == "comment" && (c.newvalue.nil? || c.newvalue.lstrip.empty?))
+      end
+
+      {
+        "issue" => {
+          "title" => "ipr.cgi",
+          "body" => "`owner:henrik@levkowetz.com` `resolution_fixed` `type_task`   |    by henrik@levkowetz.com\n\n___\n\n\n\n\n___\n_Issue migrated from trac:3 at #{Time.now}_",
+          "labels" => ["n/a", "closed", "component: admin/"],
+          "closed" => true,
+          "closed_at" => format_time(ticket.closed_comments.order(:time).last.time),
+          "created_at" => format_time(ticket[:time]),
+          "milestone" => nil,
+          "assignee" => "henrik@levkowetz.com"
+        },
+        "comments" => [
+          { "body" => "_@henrik@levkowetz.com_ _changed status from `new` to `assigned`_", "created_at" => format_time(changes[0][:time]) },
+          { "body" => "_@henrik@levkowetz.com_ _changed owner from `henrik` to `henrik@levkowetz.com`_", "created_at" => format_time(changes[1][:time]) },
+          { "body" => "_@henrik@levkowetz.com_ _changed status from `assigned` to `closed`_", "created_at" => format_time(changes[2][:time]) },
+          { "body" => "_@henrik@levkowetz.com_ _changed resolution from `` to `fixed`_", "created_at" => format_time(changes[3][:time]) },
+          { "body" => "_@fenner@research.att.com_ _changed status from `closed` to `reopened`_", "created_at" => format_time(changes[4][:time]) },
+          { "body" => "_@fenner@research.att.com_ _changed resolution from `fixed` to ``_", "created_at" => format_time(changes[5][:time]) },
+          {
+            "body" => "_@fenner@research.att.com_ _commented_\n\n\n___\nI noticed a couple of major differences between the cgi and django versions:\n\n * The cgi version displays a preview\n * The cgi version displays a message that the disclosure has been submitted and it will be reviewed and posted.  The django version sends you directly to your new disclosure, which could allow you to post a link to it before it is reviewed and posted.  (Should the view detail say \"this is under review\" instead of showing the disclousre?)\n * The cgi version sends email to the secretariat (in the same general format as the preview) as a notification of the new submission.\n\nIf nothing else, the django version should at least send the same kind of email to keep the workflow the same.", "created_at" => format_time(changes[6][:time])
+          },
+          {
+            "body" => "_@henrik@levkowetz.com_ _commented_\n\n\n___\nReplying to [comment:3 fenner@research.att.com]:\n> I noticed a couple of major differences between the cgi and django versions:\n> \n>  * The cgi version displays a preview\n\nMissing feature in django version.\n\n>  * The cgi version displays a message that the disclosure has been submitted and it will be reviewed and posted.  The django version sends you directly to your new disclosure, which could allow you to post a link to it before it is reviewed and posted.  (Should the view detail say \"this is under review\" instead of showing the disclousre?)\n\nYes. Bug in django version.\n\n>  * The cgi version sends email to the secretariat (in the same general format as the preview) as a notification of the new submission.\n\nRight. Bug (missing functionality) in django version.\n\n> If nothing else, the django version should at least send the same kind of email to keep the workflow the same.\n\nYes.", "created_at" => format_time(changes[7][:time])
+          },
+          {
+            "body" => "_@michael.lee@neustar.biz_ _commented_\n\n\n___\nI have following differences:\n\n* The cgi version allows you to submit an IPR without specifying Disclosure of Patent Information when you select 'Yes' on V.B. The django version doesn't do this.\n\n* You can submit an ipr with mixed type of IETF documentations and other contribution (section IV). There was a discussion about this a while ago and this action was prohibited. We may want to bring this up to people like Russ or Scott Bradner if we want to change this rule. If changed, then we will need to test this with secreatariat's interface to make sure the notification messages are going out to proper group of people.\n\n* There is no Review and Confirm page in django. May be this is intended?\n\nMichael.\n", "created_at" => format_time(changes[8][:time])
+          },
+          {
+            "body" => "_@henrik@levkowetz.com_ _commented_\n\n\n___\nReplying to [comment:5 michael.lee@neustar.biz]:\n> I have following differences:\n> \n> * The cgi version allows you to submit an IPR without specifying Disclosure of Patent Information when you select 'Yes' on V.B. The django version doesn't do this.\n\nI think this should be fixed.\n\n> * You can submit an ipr with mixed type of IETF documentations and other contribution (section IV). There was a discussion about this a while ago and this action was prohibited. We may want to bring this up to people like Russ or Scott Bradner if we want to change this rule. If changed, then we will need to test this with secreatariat's interface to make sure the notification messages are going out to proper group of people.\n\nI had a discussion with past chairs and others about permitting both RFCs and\ndrafts in the same disclosure (after having asked you (Michael) about this),\nand got go-ahead on that.\n\nIs this something different, or the same issue?\n\n> * There is no Review and Confirm page in django. May be this is intended?\n\nNo, but possibly sufficiently minor that we will fix it later.\n\n> Michael.\n", "created_at" => format_time(changes[9][:time])
+          },
+          {
+            "body" => "_@fenner@research.att.com_ _commented_\n\n\n___\nReplying to [comment:5 michael.lee@neustar.biz]:\n> * You can submit an ipr with mixed type of IETF documentations and other contribution (section IV). There was a discussion about this a while ago and this action was prohibited. We may want to bring this up to people like Russ or Scott Bradner if we want to change this rule. If changed, then we will need to test this with secreatariat's interface to make sure the notification messages are going out to proper group of people.\n\nI checked ipr_admin_detail.cgi, command=do_post_it - it uses both ipr_ids and ipr_rfcs and looks up the relevant people for each I-D and RFC individually and adds them all together, so it looks like it already supports it.", "created_at" => format_time(changes[10][:time])
+          },
+          { "body" => "_@henrik@levkowetz.com_ _changed status from `reopened` to `closed`_", "created_at" => format_time(changes[11][:time]) },
+          { "body" => "_@henrik@levkowetz.com_ _changed resolution from `` to `fixed`_", "created_at" => format_time(changes[12][:time]) },
+          { "body" => "_@henrik@levkowetz.com_ _changed component from `` to `admin/`_", "created_at" => format_time(changes[13][:time]) },
+          { "body" => "_removed milestone (was `IPRTool`)_", "created_at" => format_time(changes[14][:time]) },
+          { "body" => "_commented_\n\n\n___\nMilestone IPRTool deleted", "created_at" => format_time(changes[15][:time]) }
+        ]
+      }
+    end
+
     def ticket_compose_hash98(ticket)
       changes = ticket.all_changes
       changes = changes.reject do |c|


### PR DESCRIPTION
Added option to either convert owners to tags or labels on GitHub.

Fixes ietf-ribose/github-migration-project#24